### PR TITLE
drush cr ( 'all' is causing errors. )

### DIFF
--- a/.dropwhale/web/ansible/templates/phpunit.sh
+++ b/.dropwhale/web/ansible/templates/phpunit.sh
@@ -2,7 +2,7 @@
 
 # Clear the cache.
 cd {{ web_dir }}
-drush cr all
+drush cr
 
 # Run the tests.
 cd {{ web_dir }}/core/

--- a/.dropwhale/web/ansible/templates/run-js-tests.sh
+++ b/.dropwhale/web/ansible/templates/run-js-tests.sh
@@ -2,7 +2,7 @@
 
 # Clear the cache.
 cd {{ web_dir }}
-drush cr all
+drush cr
 
 # Override the default Mink settings to point at the phantomjs container.
 export MINK_DRIVER_ARGS='["http://phantomjs:8510"]'

--- a/.dropwhale/web/ansible/templates/run-tests.sh
+++ b/.dropwhale/web/ansible/templates/run-tests.sh
@@ -2,7 +2,7 @@
 
 # Clear the cache.
 cd {{ web_dir }}
-drush cr all
+drush cr
 
 # Run the tests.
 if [ -n $MODULE_NAME ] && [ -z $* ]; then


### PR DESCRIPTION
Looking at drush 9.0.0 beta9

Drush has tightened up it's  error reporting 

I have changed all instances of "drush cr all" to "drush cr" as the 'all' keyword  is meaningless and it is now causing problems 

I hope this helps. 